### PR TITLE
Fix TRPC context path

### DIFF
--- a/backend/src/utils/trpc.ts
+++ b/backend/src/utils/trpc.ts
@@ -1,5 +1,5 @@
 import { initTRPC } from '@trpc/server';
-import type { Context } from '../context';
+import type { Context } from './context';
 
 const t = initTRPC.context<Context>().create();
 


### PR DESCRIPTION
## Summary
- fix import path for Context in TRPC utils

## Testing
- `npx tsc -p frontend/tsconfig.json --noEmit` *(fails: variable type errors in routers and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68641c6146b4832fa8d05a145b52aaa9